### PR TITLE
Added getAllFiresByMonthYear API

### DIFF
--- a/backend/dataInterface/mongoDB.js
+++ b/backend/dataInterface/mongoDB.js
@@ -21,7 +21,7 @@ module.exports.getAllFires = async () => {
     const db = client.db(databaseName);
     const collection = db.collection(fire_Collection);
     // Edit limit to get all fires when in production
-    const result = await collection.find({}).limit(1).toArray();
+    const result = await collection.find({}).limit(10).toArray();
     return result;
   } catch (err) {
     return {error: 'Something is wrong. Not able to retrieve fire data.'}
@@ -115,12 +115,12 @@ module.exports.getFireCommentByCommentId = async (commentId) => {
   }
 };
 //get all fire comments by userid
-module.exports.getFireCommentsByUser = async (id) => {
+module.exports.getFireCommentsByUser = async (username) => {
   try {
     await client.connect();
     const db = client.db(databaseName);
     const collection = db.collection(comments_Collection);
-    const result = await collection.find({ username: id }).toArray();
+    const result = await collection.find({ username: username }).toArray();
     return result;
   } catch (err) {
     return {error: 'Something is wrong. Not able to retrieve fire comments.'}
@@ -227,13 +227,15 @@ module.exports.getBookmarkByUserName = async(userName) => {
     await client.connect();
     const db = client.db(databaseName);
     const collection = db.collection(bookmarks_Collection);
-    const result = await collection.find({ username: userName }).toArray();
-    return result;
+    const result = await collection.find({ username: userName });
+    return result
+    ? result.toArray()
+    : {
+      error: `We've encountered an error. Please try again later.`,
+    };
 
   } catch (err) {
-    return { error: "Failed to retrieve bookmarks for username: ${userName}" };
-  } finally {
-    await client.close();
+    return { error: `Failed to retrieve bookmarks for a username: ${userName}` };
   }
 }
 // get all bookmarks by fireid
@@ -292,11 +294,11 @@ module.exports.deleteBookmark = async (id) => {
     const result = await collection.deleteOne(deletionRules);
     if (result.deletedCount != 1) {
       return {
-        error: `Something went wrong. ${result.deletedCount} Bookmarks were deleted. Please try again.`,
+        error: `Something went wrong. 0 bookmarks were deleted. Please try again.`,
       };
     }
 
-    return { message: `Deleted ${result.deletedCount} bookmark.` };
+    return { message: `Deleted one bookmark.` };
   } catch (err) {
     return { Error: "Failed to Delete a bookmark" };
   } finally {

--- a/backend/dataInterface/mongoDB.js
+++ b/backend/dataInterface/mongoDB.js
@@ -1,7 +1,7 @@
 const { MongoClient } = require("mongodb");
 const ObjectId = require("mongodb").ObjectId;
 const bcrypt = require("bcryptjs");
-const { use } = require("../routes");
+//const { use } = require("../routes");
 const uri =
   "mongodb+srv://carlitos206:SharedFakePass123@cluster0.lshmeod.mongodb.net/?retryWrites=true&w=majority";
 
@@ -20,8 +20,8 @@ module.exports.getAllFires = async () => {
     await client.connect();
     const db = client.db(databaseName);
     const collection = db.collection(fire_Collection);
-    // Edit limit to get all fires when in prduction
-    const result = await collection.find({}).limit(10).toArray();
+    // Edit limit to get all fires when in production
+    const result = await collection.find({}).limit(1).toArray();
     return result;
   } catch (err) {
     return {error: 'Something is wrong. Not able to retrieve fire data.'}
@@ -67,9 +67,7 @@ module.exports.getFireByMonthYear = async (month, year) => {
       error: `We've encountered an error. Please try again later.`,
     };
   } catch (err) {
-    console.log(err);
-  } finally {
-    //await client.close();
+    return {error: 'Something is wrong. Not able to retrieve fire data.'}
   }
 }
 //get fire by fire id
@@ -81,7 +79,7 @@ module.exports.getFireById = async (id) => {
     const result = await collection.findOne({ _id: ObjectId(id) });
     return result;
   } catch (err) {
-    console.log(err);
+    return {error: 'Something is wrong. Not able to retrieve fire data.'}
   } finally {
     await client.close();
   }
@@ -96,7 +94,7 @@ module.exports.getFireComments = async (id) => {
     const result = await collection.find(query).toArray();
     return result;
   } catch (err) {
-    console.log(err);
+    return {error: 'Something is wrong. Not able to retrieve fire comments.'}
   } finally {
     await client.close();
   }
@@ -111,7 +109,7 @@ module.exports.getFireCommentByCommentId = async (commentId) => {
     const result = await collection.findOne(query);
     return result;
   } catch (err) {
-    console.log(err);
+    return {error: 'Something is wrong. Not able to retrieve fire comments.'}
   } finally {
     await client.close();
   }
@@ -125,21 +123,7 @@ module.exports.getFireCommentsByUser = async (id) => {
     const result = await collection.find({ username: id }).toArray();
     return result;
   } catch (err) {
-    console.log(err);
-  } finally {
-    await client.close();
-  }
-};
-//get all fire comment by fire id
-module.exports.getFireCommentsByFire = async (id) => {
-  try {
-    await client.connect();
-    const db = client.db(databaseName);
-    const collection = db.collection(comments_Collection);
-    const result = await collection.find({ fire_id: id }).toArray();
-    return result;
-  } catch (err) {
-    console.log(err);
+    return {error: 'Something is wrong. Not able to retrieve fire comments.'}
   } finally {
     await client.close();
   }
@@ -168,7 +152,7 @@ module.exports.createComment = async (paramObj, newObj) => {
       return { error: "New comment insert failed." };
     }
   } catch (err) {
-    console.log(err);
+    return {error: 'Something is wrong. Not able to insert comment.'}
   } finally {
     await client.close();
   }
@@ -258,13 +242,15 @@ module.exports.getAllBookmarksByFireId = async (id) => {
     await client.connect();
     const db = client.db(databaseName);
     const collection = db.collection(bookmarks_Collection);
-    const result = await collection.find({ fire_id: ObjectId(id) }).toArray();
-    return result;
+    const result = await collection.find({ fire_id: ObjectId(id) });
+    return result
+    ? result.toArray()
+    : {
+      error: `We've encountered an error. Please try again later.`,
+    };
 
   } catch (err) {
     return { error: "Failed to retrieve bookmarks for fire_id: ${id}" };
-  } finally {
-    await client.close();
   }
 }
 // create a bookmark by fireid and username

--- a/backend/dataInterface/mongoDB.js
+++ b/backend/dataInterface/mongoDB.js
@@ -24,11 +24,54 @@ module.exports.getAllFires = async () => {
     const result = await collection.find({}).limit(10).toArray();
     return result;
   } catch (err) {
-    console.log(err);
+    return {error: 'Something is wrong. Not able to retrieve fire data.'}
   } finally {
     await client.close();
   }
 };
+// get all fires by month and year
+module.exports.getFireByMonthYear = async (month, year) => {
+  //array to find month number by month name
+  const monthsShort = {
+    Jan: '01',
+    Feb: '02',
+    Mar: '03',
+    Apr: '04',
+    May: '05',
+    Jun: '06',
+    Jul: '07',
+    Aug: '08',
+    Sep: '09',
+    Oct: '10',
+    Nov: '11',
+    Dec: '12',
+  };
+  try {
+    await client.connect();
+    const db = client.db(databaseName);
+    const collection = db.collection(fire_Collection);
+    //get month num
+    const monthNum = monthsShort[month];
+    //contruct frmDate
+    const frmDate = `${year}-${monthNum}-01`;
+    //get month end date
+    const endDt = new Date(year, monthNum, 0);
+    // construct toDate
+    const toDate = `${year}-${monthNum}-${endDt}`;
+    // get all fires between the start and end date of a given month
+    const result = await collection.find({ fire_discovery_datetime : { $gt: frmDate, $lt: toDate}});
+
+    return result
+    ? result.toArray()
+    : {
+      error: `We've encountered an error. Please try again later.`,
+    };
+  } catch (err) {
+    console.log(err);
+  } finally {
+    //await client.close();
+  }
+}
 //get fire by fire id
 module.exports.getFireById = async (id) => {
   try {

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,4 +1,4 @@
-const cool = require('cool-ascii-faces');
+//const cool = require('cool-ascii-faces');
 const server = require("./server");
 
 const port = 5000;

--- a/backend/routes/fireRoutes.js
+++ b/backend/routes/fireRoutes.js
@@ -53,10 +53,11 @@ router.get("/:id([0-9a-fA-F]{24})", async (req, res, next) => {
     
   }
 });
+
 // get all comments by fire id
 // curl http://localhost:5000/fires/:id/comments
 // curl http://localhost:5000/fires/62fb42131c5b7ea309f7e0e0/comments
-router.get("/:id[0-9a-fA-F]{24}/comments", async (req, res, next) => {
+router.get("/:id/comments", async (req, res, next) => {
   let statusCode;
   const result = await mongoConnection.getFireComments(req.params.id);
   if (!result) {

--- a/backend/routes/fireRoutes.js
+++ b/backend/routes/fireRoutes.js
@@ -8,11 +8,28 @@ const mongoConnection = require("../dataInterface/mongoDB");
 
 // curl http://localhost:5000/fires/
 router.get("/", async (req, res) => {
+  let statusCode = 500
   const result = await mongoConnection.getAllFires();
-  if (result) {
-    res.status(200).send(result);
+  if (result.length >0) {
+    statusCode = 200
+    res.status(statusCode).send(result);
   } else {
-    res.status(200).send({ message: "Failed" });
+    res.status(statusCode).send({ error: "Failed to retrieve fire data." });
+  }
+});
+
+//get all fires by month and year
+// curl http://localhost:5000/fires/:month/:year
+// curl http://localhost:5000/fires/Jul/2014
+router.get("/:month/:year", async(req, res) => {
+  let statusCode = 500
+  const result = await mongoConnection.getFireByMonthYear(req.params.month, req.params.year);
+  if (result.length >0) {
+    statusCode = 200
+    console.log("arraylength: ",result.length);
+    res.status(statusCode).send(result);
+  } else {
+    res.status(statusCode).send({ error: "Failed to retrieve fire data." });
   }
 });
 

--- a/backend/routes/fireRoutes.test.js
+++ b/backend/routes/fireRoutes.test.js
@@ -6,7 +6,7 @@ jest.mock("../dataInterface/mongoDB");
 const mongoData = require("../dataInterface/mongoDB");
 
 describe("/fires routes", () => {
-
+  // test get all fires
   describe("GET /fires", () =>{
     it("should return an array of fire data on success", async () => {
       mongoData.getAllFires.mockResolvedValue([{
@@ -46,14 +46,17 @@ describe("/fires routes", () => {
       expect(Array.isArray(res.body)).toEqual(true);
       expect(res.body.error).not.toBeDefined();
     });
+     
     it("should return a status code of 500 on failure", async () => {
-      mongoData.getAllFires.mockResolvedValue();
+      mongoData.getAllFires.mockResolvedValue({"error": "Failed to retrieve fire data."});
       const res = await request(server).get("/fires");
       expect(res.statusCode).toEqual(500);
       expect(res.body.error).toBeDefined();
     });
+    
   });
 
+<<<<<<< Updated upstream
   describe("GET /fires/:id", () =>{
     it("should return a fire's data on success", async () => {
       mongoData.getFireById.mockResolvedValue({
@@ -208,5 +211,34 @@ describe("/fires routes", () => {
       expect(res.body.error).toBeDefined();
     });
   });
+=======
+  // test get fire by id
+
+  // test  get all comments by fire id
+
+  // test get comment by comment id
+
+  // test get all comments by userid
+
+  // test create comment by fire id , username
+
+  // test modify comment by comment id
+
+  // test delete comment by comment id
+
+  // test get a bookmakr by a  bookmark id
+
+  // test get all bookmarks by username
+
+  // test get all bookmarks by fireid
+
+  // create a bookmark by fireid and username
+
+  // remove bookmark by bookmarkid
+
+
+
+  
+>>>>>>> Stashed changes
 
 });

--- a/backend/routes/fireRoutes.test.js
+++ b/backend/routes/fireRoutes.test.js
@@ -53,10 +53,114 @@ describe("/fires routes", () => {
       expect(res.statusCode).toEqual(500);
       expect(res.body.error).toBeDefined();
     });
-    
+    // test fires by fireid
+    describe("GET /fires/:id", () => {
+      it("should return a fire's data on success", async () => {
+        mongoData.getFireById.mockResolvedValue({
+          _id: "62fb42131c5b7ea309f7e0e0",
+          total_acres: null,
+          containment_datetime: "2014-08-24T18:59:59Z",
+          control_datetime: "2014-08-24T19:01:00Z",
+          daily_acres: 0.1,
+          discovery_acres: null,
+          estimated_cost_to_date: null,
+          final_fire_report_approved_date: null,
+          fire_origin: {
+            cause: "Natural",
+            general: null,
+            specific: null,
+          },
+          fire_discovery_datetime: "2014-07-17T20:07:59Z",
+          fire_out_datetime: "2014-08-28T18:59:59Z",
+          incident_name: "DUNCAN HILL 2-ENTIAT",
+          location: {
+            latitude: null,
+            longitude: null,
+            city: null,
+            county: "Chelan",
+            state: "US-WA",
+          },
+          predominant_fuel_group: null,
+          modified_by_system: "wfdss",
+          created_on_datetime: "2014-08-29T01:20:27Z",
+          modified_on_datetime: "2014-08-29T18:46:06Z",
+          source: "IRWIN",
+          admin: {
+            created: "2022-08-16T07:06:59.277Z",
+            modified: null,
+          },
+        });
+        const res = await request(server).get(
+          "/fires/62fb42131c5b7ea309f7e0e0"
+        );
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.error).not.toBeDefined();
+      });
+      it("should return a status code of 404 on failure", async () => {
+        mongoData.getFireById.mockResolvedValue(null);
+        const res = await request(server).get("/fires/62fb42131c5b7ea309f7e0e0");
+        expect(res.statusCode).toEqual(404);
+        expect(res.body.error).toBeDefined();
+      });
+    });
   });
+  // test get a bookmark by a bookmark id
+describe("GET /fires/bookmarks/:id", () => {
+  it("should return a bookmark on success", async () => {
+  mongoData.getBookmarkByBookmarkId.mockResolvedValue({
+    _id: "6303e187a84112a7a4be6752",
+    username: "User1",
+    fire_id: "62fb42181c5b7ea309f7e0e8",
+    createdDate: "2022-08-21T07:00:00.000+00:00",
+  });
+  const res = await request(server).get("/fires/bookmarks/6303e187a84112a7a4be6752");
+  expect(res.statusCode).toEqual(200);
+  expect(Array.isArray(res.body)).toEqual(false);
+  expect(res.body.error).not.toBeDefined();
+  });
+  it("should return a status code of 404 if bookmark not found", async () => {
+    mongoData.getBookmarkByBookmarkId.mockResolvedValue(null);
+    const res = await request(server).get("/fires/bookmarks/6303e187a84112a7a4be6752");
+    expect(res.statusCode).toEqual(404);
+    expect(res.body.error).toBeDefined();
+  });
+});
 
-<<<<<<< Updated upstream
+// test get all bookmarks by username
+describe("GET /fires/user/:username/bookmarks", () => {
+ it("should return all bookmarks belong to a username on success", async () => {
+  mongoData.getBookmarkByUserName.mockResolvedValue([{
+    _id: "6303ec16a84112a7a4be6753",  
+    username: "User1",
+    fire_id: "62fb42181c5b7ea309f7e0e8",
+    createdDate: "2022-08-21T07:00:00.000Z"
+  },
+  {
+    _id: "6303f55f984a6bbf4f98e6f6",  
+    username: "User1",
+    fire_id: "62fb42131c5b7ea309f7e0e0",
+    createdDate: "2022-08-22T21:30:07.487Z"
+  }
+  ]);
+  const res = await request(server).get("fires/user/User1/bookmarks");
+  expect(res.statusCode).toEqual(404);
+  expect(Array.isArray(res.body)).toEqual(true);
+  expect(res.body.error).not.toBeDefined();
+ });
+ it("should return a status code of 404 if bookmark not found", async () => {
+  mongoData.getBookmarkByUserName.mockResolvedValue(null);
+  const res = await request(server).get("/fires/user/User1/bookmarks");
+  expect(res.statusCode).toEqual(404);
+  expect(res.body.error).toBeDefined();
+  });
+});
+  // test get all bookmarks by fireid
+
+  // create a bookmark by fireid and username
+
+  // remove bookmark by bookmarkid
+});
+/**
   describe("GET /fires/:id", () =>{
     it("should return a fire's data on success", async () => {
       mongoData.getFireById.mockResolvedValue({
@@ -211,7 +315,9 @@ describe("/fires routes", () => {
       expect(res.body.error).toBeDefined();
     });
   });
-=======
+
+  //test get all fires by MonthYear
+
   // test get fire by id
 
   // test  get all comments by fire id
@@ -226,19 +332,5 @@ describe("/fires routes", () => {
 
   // test delete comment by comment id
 
-  // test get a bookmakr by a  bookmark id
-
-  // test get all bookmarks by username
-
-  // test get all bookmarks by fireid
-
-  // create a bookmark by fireid and username
-
-  // remove bookmark by bookmarkid
-
-
-
   
->>>>>>> Stashed changes
-
-});
+*/

--- a/backend/routes/fireRoutes.test.js
+++ b/backend/routes/fireRoutes.test.js
@@ -161,7 +161,7 @@ describe("/fires routes", () => {
     });
   });
   // test  get all comments by fire id
-  /**
+  
   describe("GET /fires/:id/comments", () =>{
     it("should return an array of fire's comments on success", async () => {
       mongoData.getFireComments.mockResolvedValue([{
@@ -183,7 +183,7 @@ describe("/fires routes", () => {
       expect(res.body.error).toBeDefined();
     });
   });
-  **/
+  
   // test get comment by comment id
   describe("GET /comments/:id", () => {
     it("should return a single comment for a given comment id on success", async () => {

--- a/backend/routes/fireRoutes.test.js
+++ b/backend/routes/fireRoutes.test.js
@@ -7,48 +7,54 @@ const mongoData = require("../dataInterface/mongoDB");
 
 describe("/fires routes", () => {
   // test get all fires
-  describe("GET /fires", () =>{
+  describe("GET /fires", () => {
     it("should return an array of fire data on success", async () => {
-      mongoData.getAllFires.mockResolvedValue([{
-        "_id":"62fb42131c5b7ea309f7e0e0",
-        "total_acres":null,
-        "containment_datetime":"2014-08-24T18:59:59Z",
-        "control_datetime":"2014-08-24T19:01:00Z",
-        "daily_acres":0.1,"discovery_acres":null,
-        "estimated_cost_to_date":null,
-        "final_fire_report_approved_date":null,
-        "fire_origin":{
-          "cause":"Natural",
-          "general":null,
-          "specific":null
+      mongoData.getAllFires.mockResolvedValue([
+        {
+          _id: "62fb42131c5b7ea309f7e0e0",
+          total_acres: null,
+          containment_datetime: "2014-08-24T18:59:59Z",
+          control_datetime: "2014-08-24T19:01:00Z",
+          daily_acres: 0.1,
+          discovery_acres: null,
+          estimated_cost_to_date: null,
+          final_fire_report_approved_date: null,
+          fire_origin: {
+            cause: "Natural",
+            general: null,
+            specific: null,
+          },
+          fire_discovery_datetime: "2014-07-17T20:07:59Z",
+          fire_out_datetime: "2014-08-28T18:59:59Z",
+          incident_name: "DUNCAN HILL 2-ENTIAT",
+          location: {
+            latitude: null,
+            longitude: null,
+            city: null,
+            county: "Chelan",
+            state: "US-WA",
+          },
+          predominant_fuel_group: null,
+          modified_by_system: "wfdss",
+          created_on_datetime: "2014-08-29T01:20:27Z",
+          modified_on_datetime: "2014-08-29T18:46:06Z",
+          source: "IRWIN",
+          admin: {
+            created: "2022-08-16T07:06:59.277Z",
+            modified: null,
+          },
         },
-        "fire_discovery_datetime":"2014-07-17T20:07:59Z",
-        "fire_out_datetime":"2014-08-28T18:59:59Z",
-        "incident_name":"DUNCAN HILL 2-ENTIAT",
-        "location":{
-          "latitude":null,
-          "longitude":null,
-          "city":null,
-          "county":"Chelan",
-          "state":"US-WA"
-        },
-        "predominant_fuel_group":null,
-        "modified_by_system":"wfdss",
-        "created_on_datetime":"2014-08-29T01:20:27Z",
-        "modified_on_datetime":"2014-08-29T18:46:06Z",
-        "source":"IRWIN",
-        "admin":{
-          "created":"2022-08-16T07:06:59.277Z",
-          "modified":null
-        }}]);
+      ]);
       const res = await request(server).get("/fires");
       expect(res.statusCode).toEqual(200);
       expect(Array.isArray(res.body)).toEqual(true);
       expect(res.body.error).not.toBeDefined();
     });
-     
+
     it("should return a status code of 500 on failure", async () => {
-      mongoData.getAllFires.mockResolvedValue({"error": "Failed to retrieve fire data."});
+      mongoData.getAllFires.mockResolvedValue({
+        error: "Failed to retrieve fire data.",
+      });
       const res = await request(server).get("/fires");
       expect(res.statusCode).toEqual(500);
       expect(res.body.error).toBeDefined();
@@ -98,239 +104,353 @@ describe("/fires routes", () => {
       });
       it("should return a status code of 404 on failure", async () => {
         mongoData.getFireById.mockResolvedValue(null);
-        const res = await request(server).get("/fires/62fb42131c5b7ea309f7e0e0");
+        const res = await request(server).get(
+          "/fires/62fb42131c5b7ea309f7e0e0"
+        );
         expect(res.statusCode).toEqual(404);
         expect(res.body.error).toBeDefined();
       });
     });
   });
-  // test get a bookmark by a bookmark id
-describe("GET /fires/bookmarks/:id", () => {
-  it("should return a bookmark on success", async () => {
-  mongoData.getBookmarkByBookmarkId.mockResolvedValue({
-    _id: "6303e187a84112a7a4be6752",
-    username: "User1",
-    fire_id: "62fb42181c5b7ea309f7e0e8",
-    createdDate: "2022-08-21T07:00:00.000+00:00",
-  });
-  const res = await request(server).get("/fires/bookmarks/6303e187a84112a7a4be6752");
-  expect(res.statusCode).toEqual(200);
-  expect(Array.isArray(res.body)).toEqual(false);
-  expect(res.body.error).not.toBeDefined();
-  });
-  it("should return a status code of 404 if bookmark not found", async () => {
-    mongoData.getBookmarkByBookmarkId.mockResolvedValue(null);
-    const res = await request(server).get("/fires/bookmarks/6303e187a84112a7a4be6752");
-    expect(res.statusCode).toEqual(404);
-    expect(res.body.error).toBeDefined();
-  });
-});
-
-// test get all bookmarks by username
-describe("GET /fires/user/:username/bookmarks", () => {
- it("should return all bookmarks belong to a username on success", async () => {
-  mongoData.getBookmarkByUserName.mockResolvedValue([{
-    _id: "6303ec16a84112a7a4be6753",  
-    username: "User1",
-    fire_id: "62fb42181c5b7ea309f7e0e8",
-    createdDate: "2022-08-21T07:00:00.000Z"
-  },
-  {
-    _id: "6303f55f984a6bbf4f98e6f6",  
-    username: "User1",
-    fire_id: "62fb42131c5b7ea309f7e0e0",
-    createdDate: "2022-08-22T21:30:07.487Z"
-  }
-  ]);
-  const res = await request(server).get("fires/user/User1/bookmarks");
-  expect(res.statusCode).toEqual(404);
-  expect(Array.isArray(res.body)).toEqual(true);
-  expect(res.body.error).not.toBeDefined();
- });
- it("should return a status code of 404 if bookmark not found", async () => {
-  mongoData.getBookmarkByUserName.mockResolvedValue(null);
-  const res = await request(server).get("/fires/user/User1/bookmarks");
-  expect(res.statusCode).toEqual(404);
-  expect(res.body.error).toBeDefined();
-  });
-});
-  // test get all bookmarks by fireid
-
-  // create a bookmark by fireid and username
-
-  // remove bookmark by bookmarkid
-});
-/**
-  describe("GET /fires/:id", () =>{
+  // test get all fires by month and year
+  describe("GET /fires/in/:month/:year", () => {
     it("should return a fire's data on success", async () => {
-      mongoData.getFireById.mockResolvedValue({
-        "_id":"62fb42131c5b7ea309f7e0e0",
-        "total_acres":null,
-        "containment_datetime":"2014-08-24T18:59:59Z",
-        "control_datetime":"2014-08-24T19:01:00Z",
-        "daily_acres":0.1,"discovery_acres":null,
-        "estimated_cost_to_date":null,
-        "final_fire_report_approved_date":null,
-        "fire_origin":{
-          "cause":"Natural",
-          "general":null,
-          "specific":null
+      mongoData.getFireByMonthYear.mockResolvedValue({
+        _id: "62fb42131c5b7ea309f7e0e0",
+        total_acres: null,
+        containment_datetime: "2014-08-24T18:59:59Z",
+        control_datetime: "2014-08-24T19:01:00Z",
+        daily_acres: 0.1,
+        discovery_acres: null,
+        estimated_cost_to_date: null,
+        final_fire_report_approved_date: null,
+        fire_origin: {
+          cause: "Natural",
+          general: null,
+          specific: null,
         },
-        "fire_discovery_datetime":"2014-07-17T20:07:59Z",
-        "fire_out_datetime":"2014-08-28T18:59:59Z",
-        "incident_name":"DUNCAN HILL 2-ENTIAT",
-        "location":{
-          "latitude":null,
-          "longitude":null,
-          "city":null,
-          "county":"Chelan",
-          "state":"US-WA"
+        fire_discovery_datetime: "2014-07-17T20:07:59Z",
+        fire_out_datetime: "2014-08-28T18:59:59Z",
+        incident_name: "DUNCAN HILL 2-ENTIAT",
+        location: {
+          latitude: null,
+          longitude: null,
+          city: null,
+          county: "Chelan",
+          state: "US-WA",
         },
-        "predominant_fuel_group":null,
-        "modified_by_system":"wfdss",
-        "created_on_datetime":"2014-08-29T01:20:27Z",
-        "modified_on_datetime":"2014-08-29T18:46:06Z",
-        "source":"IRWIN",
-        "admin":{
-          "created":"2022-08-16T07:06:59.277Z",
-          "modified":null
-        }});
-      const res = await request(server).get("/fires/62fb42131c5b7ea309f7e0e0");
+        predominant_fuel_group: null,
+        modified_by_system: "wfdss",
+        created_on_datetime: "2014-08-29T01:20:27Z",
+        modified_on_datetime: "2014-08-29T18:46:06Z",
+        source: "IRWIN",
+        admin: {
+          created: "2022-08-16T07:06:59.277Z",
+          modified: null,
+        },
+      });
+      const res = await request(server).get("/fires/in/Jul/2014");
       expect(res.statusCode).toEqual(200);
       expect(res.body.error).not.toBeDefined();
     });
-    it("should return a status code of 500 on failure", async () => {
-      mongoData.getFireById.mockResolvedValue();
-      const res = await request(server).get("/fires/abc");
-      expect(res.statusCode).toEqual(500);
-      expect(res.body.error).toBeDefined();
-    });
-  });
-
-  describe("POST /fires", () =>{
-    it("should return a success message with the new fire's id on success", async () => {
-      mongoData.getFireById.mockResolvedValue({
-        "newObjectId": "$#!&$#!&$#!",
-        "message": "Fire created! ID: $#!&$#!&$#!"
-      });
-      const res = await request(server).post("/fires");
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.error).not.toBeDefined();
-    });
-    it("should return a status code of 500 on failure", async () => {
-      mongoData.getFireById.mockResolvedValue();
-      const res = await request(server).post("/fires");
-      expect(res.statusCode).toEqual(500);
-      expect(res.body.error).toBeDefined();
-    });
-  });
-
-  describe("GET /fires/comments/:id", () =>{
-    it("should return a single comment's data on success", async () => {
-      mongoData.getFireCommentByCommentId.mockResolvedValue({
-        "_id":"630250491f3d48c59da2eec7",
-        "username":"User1",
-        "text":"Khanh Test fire comments",
-        "fire_id":"62fb42131c5b7ea309f7e0e0",
-        "createdDate":"2022-08-22T07:00:00.000Z"
-      });
-      const res = await request(server).get("/fires/comments/630250491f3d48c59da2eec7");
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.error).not.toBeDefined();
-    });
-    it("should return status code 404 if comment is not found", async () => {
-      mongoData.getFireCommentByCommentId.mockResolvedValue({
-        "error": "No comments found for commentId: abc"
-      });
-      const res = await request(server).get("/fires/comments/abc");
+    it("should return a status code of 404 on failure", async () => {
+      mongoData.getFireByMonthYear.mockResolvedValue(null);
+      const res = await request(server).get("/fires/in/May/2014");
       expect(res.statusCode).toEqual(404);
       expect(res.body.error).toBeDefined();
     });
   });
-
-  describe("GET /fires/comments/user/:id", () =>{
-    it("should return an array of user's comments on success", async () => {
-      mongoData.getFireCommentsByUser.mockResolvedValue([{
-        "_id":"630250491f3d48c59da2eec7",
-        "username":"User1",
-        "text":"Khanh Test fire comments",
-        "fire_id":"62fb42131c5b7ea309f7e0e0",
-        "createdDate":"2022-08-22T07:00:00.000Z"
-      }]);
-      const res = await request(server).get("/fires/comments/user/User1");
-      expect(Array.isArray(res.body)).toEqual(true);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.error).not.toBeDefined();
-    });
-    it("should return status code 404 if user is not found", async () => {
-      mongoData.getFireCommentsByUser.mockResolvedValue({
-        "message": "No comments found for userId: ${req.params.id}"
-      });
-      const res = await request(server).get("/fires/comments/user/abc")
-      expect(res.statusCode).toEqual(404);
-      expect(res.body.error).toBeDefined();
-    });
-  });
-
+  // test  get all comments by fire id
+  /**
   describe("GET /fires/:id/comments", () =>{
     it("should return an array of fire's comments on success", async () => {
-      mongoData.getFireCommentsByFire.mockResolvedValue([{
+      mongoData.getFireComments.mockResolvedValue([{
         "_id":"630250491f3d48c59da2eec7",
         "username":"User1",
         "text":"Khanh Test fire comments",
         "fire_id":"62fb42131c5b7ea309f7e0e0",
         "createdDate":"2022-08-22T07:00:00.000Z"
-      }]);
+      },]);
       const res = await request(server).get("/fires/62fb42131c5b7ea309f7e0e0/comments");
       expect(Array.isArray(res.body)).toEqual(true);
       expect(res.statusCode).toEqual(200);
       expect(res.body.error).not.toBeDefined();
     });
     it("should return status code 404 if fire is not found", async () => {
-      mongoData.getFireCommentsByFire.mockResolvedValue({
-        "error": "No comments found for fireid: abc"
+      mongoData.getFireComments.mockResolvedValue(null);
+      const res = await request(server).get("/fires/62fb42131c5b7ea309f7e0e0/comments");
+      expect(res.statusCode).toEqual(404);
+      expect(res.body.error).toBeDefined();
+    });
+  });
+  **/
+  // test get comment by comment id
+  describe("GET /comments/:id", () => {
+    it("should return a single comment for a given comment id on success", async () => {
+      mongoData.getFireCommentByCommentId.mockResolvedValue([
+        {
+          _id: "630250491f3d48c59da2eec7",
+          username: "User1",
+          text: "Khanh Test fire comments",
+          fire_id: "62fb42131c5b7ea309f7e0e0",
+          createdDate: "2022-08-22T07:00:00.000Z",
+        },
+      ]);
+      const res = await request(server).get(
+        "/fires/comments/5a9427648b0beebeb6957bda"
+      );
+      expect(res.statusCode).toEqual(200);
+      expect(Array.isArray(res.body)).toEqual(true);
+      expect(res.body.error).not.toBeDefined();
+    });
+    it("should return a status code of 404 if comment not found", async () => {
+      mongoData.getFireCommentByCommentId.mockResolvedValue(null);
+      const res = await request(server).get(
+        "/fires/comments/5a9427648b0beebeb6957bdc"
+      );
+      expect(res.statusCode).toEqual(404);
+    });
+  });
+  // test get all comments by username
+  describe("GET /comments/user/:username", () => {
+    it("should return comments for a given username on success", async () => {
+      mongoData.getFireCommentsByUser.mockResolvedValue([
+        {
+          _id: "630250491f3d48c59da2eec7",
+          username: "User1",
+          text: "Khanh Test fire comments",
+          fire_id: "62fb42131c5b7ea309f7e0e0",
+          createdDate: "2022-08-22T07:00:00.000Z",
+        },
+      ]);
+      const res = await request(server).get("/fires/comments/user/User1");
+      expect(res.statusCode).toEqual(200);
+      expect(Array.isArray(res.body)).toEqual(true);
+      expect(res.body.error).not.toBeDefined();
+    });
+    it("should return a status code of 404 if comment not found", async () => {
+      mongoData.getFireCommentsByUser.mockResolvedValue(null);
+      const res = await request(server).get("/fires/comments/user/User0");
+      expect(res.statusCode).toEqual(404);
+    });
+  });
+  // test create comment by fire id , username
+  // curl -X POST -H "Content-Type: application/json" -d '{"text":"Khanh test creating comment"}' http://localhost:5000/fires/62fb42131c5b7ea309f7e0e0/user/User1/comments
+  describe("POST /:id/user/:username/comments", () => {
+    it("should return the comment for a fireid and username on success", async () => {
+      mongoData.createComment.mockResolvedValue({
+        newObjectId: "630a10d2b0cbaf4fe936e835",
+        message: "Comment created! ID: 630a10d2b0cbaf4fe936e835",
       });
-      const res = await request(server).get("/fires/abc/comments");
+      const res = await request(server)
+        .post("/fires/573a1391f29313caabcd8978/user/User1/comments")
+        .send({ text: "Something..." });
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.error).not.toBeDefined();
+    });
+    it("should return an error message if username param is missing", async () => {
+      mongoData.createComment.mockResolvedValue({
+        error: "UserName must not be blank.",
+      });
+      const res = await request(server)
+        .post("/fires/573a13a3f29313caabd0e77b/user//comments")
+        .send({ text: "Username is missing..." });
+      expect(res.statusCode).toEqual(404);
+    });
+    it("should return an error message if body is missing comment text", async () => {
+      mongoData.createComment.mockResolvedValue({
+        error: "Comments must not be blank.",
+      });
+      const res = await request(server)
+        .post("/fires/573a13a3f29313caabd0e77b/user/User1/comments")
+        .send({ text: "" });
+      expect(res.statusCode).toEqual(400);
+    });
+    it("should return an error message if comment fails to be created", async () => {
+      mongoData.createComment.mockResolvedValue({
+        error: "Something went wrong. Please try again.",
+      });
+      const res = await request(server)
+        .post("/fires/badroute/user/User1/comments")
+        .send({ text: "Something..." });
+      expect(res.statusCode).toEqual(404);
+    });
+  });
+  // test modify comment by comment id
+  // curl -X PUT -H "Content-Type: application/json" -d '{"text": "Updated comment..."}' http://localhost:5000/fires/comments/6303d66a816e5c3e74ac0980
+  describe("PUT /comments/:id", () => {
+    it("should return the updated comment on success", async () => {
+      mongoData.updateComment.mockResolvedValue({
+        _id: "573a13a3f29313caabd0e77b",
+        text: "Updated comment...",
+      });
+      const res = await request(server)
+        .put("/fires/comments/5a9427648b0beebeb6957bda")
+        .send({ text: "Updated comment..." });
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.error).not.toBeDefined();
+    });
+    it("should return an error message if a comment fails to be updated", async () => {
+      mongoData.updateComment.mockResolvedValue({
+        error: "Something went wrong. Please try again!",
+      });
+      const res = await request(server)
+        .put("/fires/comments/5a9427648b0beebeb6957bda")
+        .send();
+      expect(res.statusCode).toEqual(404);
+    });
+  });
+  // test delete comment by comment id
+  //  curl -X DELETE http://localhost:5000/fires/comments/6303d66a816e5c3e74ac0980
+  describe("DELETE /comments/:id", () => {
+    it("should return a message on success", async () => {
+      mongoData.deleteComment.mockResolvedValue({
+        message: "Deleted 1 comment.",
+      });
+      const res = await request(server)
+        .delete("/fires/comments/62e082f7b04837f399c01a2b")
+        .send();
+      expect(res.statusCode).toEqual(200);
+    });
+    it("should return a error message if a comment fails to be deleted", async () => {
+      mongoData.deleteComment.mockResolvedValue({
+        Error: "Failed to Delete Comment",
+      });
+      const res = await request(server).delete("/fires/comments").send();
+      expect(res.statusCode).toEqual(404);
+    });
+  });
+  // test get a bookmark by a bookmark id
+  describe("GET /fires/bookmarks/:id", () => {
+    it("should return a bookmark on success", async () => {
+      mongoData.getBookmarkByBookmarkId.mockResolvedValue({
+        _id: "6303e187a84112a7a4be6752",
+        username: "User1",
+        fire_id: "62fb42181c5b7ea309f7e0e8",
+        createdDate: "2022-08-21T07:00:00.000+00:00",
+      });
+      const res = await request(server).get(
+        "/fires/bookmarks/6303e187a84112a7a4be6752"
+      );
+      expect(res.statusCode).toEqual(200);
+      expect(Array.isArray(res.body)).toEqual(false);
+      expect(res.body.error).not.toBeDefined();
+    });
+    it("should return a status code of 404 if bookmark not found", async () => {
+      mongoData.getBookmarkByBookmarkId.mockResolvedValue(null);
+      const res = await request(server).get(
+        "/fires/bookmarks/6303e187a84112a7a4be6752"
+      );
       expect(res.statusCode).toEqual(404);
       expect(res.body.error).toBeDefined();
     });
   });
 
-  describe("POST /fires/:fireId/user/:userId/comments", () =>{
-    it("should return a success message with the new comment's id on success", async () => {
-      mongoData.createComment.mockResolvedValue({
-        "newObjectId":"63041c5a1f1480d6cecaa999",
-        "message":"Comment created! ID: 63041c5a1f1480d6cecaa999"
-      });
-      const res = await request(server).post("/fires/62fb42131c5b7ea309f7e0e0/user/User1/comments");
+  // test get all bookmarks by username
+  describe("GET /fires/user/:username/bookmarks", () => {
+    it("should return all bookmarks belong to a username on success", async () => {
+      mongoData.getBookmarkByUserName.mockResolvedValue([
+        {
+          _id: "6303ec16a84112a7a4be6753",
+          username: "User1",
+          fire_id: "62fb42181c5b7ea309f7e0e8",
+          createdDate: "2022-08-21T07:00:00.000Z",
+        },
+      ]);
+      const res = await request(server).get("/fires/user/User1/bookmarks");
       expect(res.statusCode).toEqual(200);
+      expect(Array.isArray(res.body)).toEqual(true);
       expect(res.body.error).not.toBeDefined();
     });
-    it("should return status code 400 if input is valid", async () => {
-      mongoData.createComment.mockResolvedValue({
-        "error": "New comment insert failed."
-      });
-      const res = await request(server).post("/fires/62fb42131c5b7ea309f7e0e0/user/User1/comments");
-      expect(res.statusCode).toEqual(400);
+    it("should return a status code of 404 if bookmark not found", async () => {
+      mongoData.getBookmarkByUserName.mockResolvedValue(null);
+      const res = await request(server).get("/fires/user/User1/bookmarks");
+      expect(res.statusCode).toEqual(404);
       expect(res.body.error).toBeDefined();
     });
   });
+  // test get all bookmarks by fireid
+  describe("GET /fires/:id/bookmarks", () => {
+    it("should return all bookmarks belong to a fireid on success", async () => {
+      mongoData.getAllBookmarksByFireId.mockResolvedValue([
+        {
+          _id: "6303ec16a84112a7a4be6753",
+          username: "User1",
+          fire_id: "62fb42181c5b7ea309f7e0e8",
+          createdDate: "2022-08-21T07:00:00.000Z",
+        },
+      ]);
+      const res = await request(server).get(
+        "/fires/62fb42181c5b7ea309f7e0e8/bookmarks"
+      );
+      expect(res.statusCode).toEqual(200);
+      expect(Array.isArray(res.body)).toEqual(true);
+      expect(res.body.error).not.toBeDefined();
+    });
+    it("should return a status code of 404 if bookmark not found", async () => {
+      mongoData.getAllBookmarksByFireId.mockResolvedValue(null);
+      const res = await request(server).get(
+        "/fires/62fb42181c5b7ea309f7e0e8/bookmarks"
+      );
+      expect(res.statusCode).toEqual(404);
+      expect(res.body.error).toBeDefined();
+    });
+  });
+  // create a bookmark by fireid and username
+  // curl -X POST -H "Content-Type: application/json" -d '{}' http://localhost:5000/fires/62fb42181c5b7ea309f7e0e9/user/User1/bookmarks
+  describe("POST /", () => {
+    it("should return the bookmark for a fireid and userid on success", async () => {
+      mongoData.createBookmark.mockResolvedValue({
+        newObjectId: "63095e9d1b9bf737af33097c",
+        message: "Bookmark created! ID: 63095e9d1b9bf737af33097c",
+      });
+      const res = await request(server)
+        .post("/fires/62fb42181c5b7ea309f7e0e9/user/User1/bookmarks")
+        .send({});
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.error).not.toBeDefined();
+    });
+    it("should return an error message if missing userid", async () => {
+      mongoData.createBookmark.mockResolvedValue({
+        error: "UserName must not be blank.",
+      });
+      const res = await request(server)
+        .post("/fires/62fb42181c5b7ea309f7e0e9/user//bookmarks")
+        .send({});
+      expect(res.statusCode).toEqual(404);
+    });
+    it("should return an error message if bookmark not created", async () => {
+      mongoData.createBookmark.mockResolvedValue({
+        error: "Something went wrong. Please try again.",
+      });
+      const res = await request(server)
+        .post("/fires/62fb42181c5b7ea309f7e0e9/user/User1/bookmarks")
+        .send({});
+      expect(res.statusCode).toEqual(500);
+    });
+  });
 
-  //test get all fires by MonthYear
+  // remove bookmark by bookmarkid
+  describe("DELETE /bookmarks/:id", () => {
+    it("should return a message on success", async () => {
+      mongoData.deleteBookmark.mockResolvedValue({
+        message: "Deleted one bookmark.",
+      });
+      const res = await request(server)
+        .delete("/fires/bookmarks/62e082f7b04837f399c01a2b")
+        .send();
+      expect(res.statusCode).toEqual(200);
+    });
+    it("should return a error message if a bookmark fails to be deleted", async () => {
+      mongoData.deleteBookmark.mockResolvedValue({
+        error:
+          "Something went wrong. 0 bookmarks were deleted. Please try again.",
+      });
+      const res = await request(server)
+        .delete("/fires/bookmarks/62e082f7b04837f399c01a2b")
+        .send();
+      expect(res.statusCode).toEqual(404);
+    });
+  });
+});
 
-  // test get fire by id
-
-  // test  get all comments by fire id
-
-  // test get comment by comment id
-
-  // test get all comments by userid
-
-  // test create comment by fire id , username
-
-  // test modify comment by comment id
-
-  // test delete comment by comment id
-
-  
-*/


### PR DESCRIPTION
I am able to complete the API to get all fires within a month and year.  Please add two drop downs one is month - e.g: Jan, Feb, Mar... and another one is year: yyyy to the front end.   The dropdown should default to current Month and Year.

The curl command should be as the followings:
// curl http://localhost:5000/fires/in/:month/:year
// curl http://localhost:5000/fires/in/Jul/2014

Code checked in and pull request created.